### PR TITLE
Step 0 Bug Fix

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,6 +16,7 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
+    this->pendingTrades = std::vector<Trade>();
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,13 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerPendingClearTest) {
+    RiskTracker riskTracker(0, std::vector<Trade>());
+    riskTracker.addTrade((Trade(10, true, 1.2)));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 12, 1e-4);
+    riskTracker.addTrade((Trade(10, true, 1.2)));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 24, 1e-4);
+}


### PR DESCRIPTION
Purpose
Fix bug where risk is being overcounted.

Changes
Clear the pending trades once trades have been updated by making the pending trades vector empty once the running risk has been calculated, so old trades are not readded to the total risk.

Bugs
Trades are being reevaluated even after the total risk has been updated.

I struggled with figuring out what the intended behavior of the code is supposed to be and figuring out the structure of the cmake file.